### PR TITLE
Display initial values in settings modal

### DIFF
--- a/whiteboard/blocks/UtilityBlock.ts
+++ b/whiteboard/blocks/UtilityBlock.ts
@@ -85,7 +85,7 @@ export async function buildHeaderBlockAfterPermission(
         UtilityEnum.PREVIEW_BLOCK_ID,
         UtilityEnum.SETTINGS_BUTTON_ACTION_ID,
         appId,
-        "Settings",
+        `${boardURL}, ${boardname}`,
         undefined
     );
 
@@ -163,7 +163,7 @@ export async function permissionHeaderBlock(
         `${username}, ${boardname}, ${userForBoardPermission}`,
         ButtonStyle.PRIMARY
     );
-    
+
 
     const denyPermissionButton = getButton(
         "Deny",

--- a/whiteboard/modals/SettingsModal.ts
+++ b/whiteboard/modals/SettingsModal.ts
@@ -14,7 +14,9 @@ import {
 
 export async function SettingsModal(
     appId: string,
-    messageId: string
+    messageId: string,
+    boardName?: string,
+    boardStatus?: string,
 ): Promise<IUIKitSurfaceViewParam> {
     const block: Block[] = [];
 
@@ -28,7 +30,8 @@ export async function SettingsModal(
         UtilityEnum.BOARD_INPUT_PLACEHOLDER,
         UtilityEnum.BOARD_INPUT_BLOCK_ID,
         UtilityEnum.BOARD_INPUT_ACTION_ID,
-        appId
+        appId,
+        boardName,
     );
     block.push(boardInputBlock);
 
@@ -55,7 +58,8 @@ export async function SettingsModal(
         options,
         appId,
         UtilityEnum.BOARD_SELECT_BLOCK_ID,
-        UtilityEnum.BOARD_SELECT_ACTION_ID
+        UtilityEnum.BOARD_SELECT_ACTION_ID,
+        boardStatus === "Public" ? UtilityEnum.PUBLIC : UtilityEnum.PRIVATE,
     );
 
     // Event handling for dropdown selection

--- a/whiteboard/persistence/boardInteraction.ts
+++ b/whiteboard/persistence/boardInteraction.ts
@@ -80,7 +80,7 @@ export const storeBoardRecord = async (
 // query all records within the "scope" - room
 export const getBoardRecordByRoomId = async (
     persistenceRead: IPersistenceRead,
-    roomId: string
+    roomId: string | undefined,
 ): Promise<any> => {
     const association = new RocketChatAssociationRecord(
         RocketChatAssociationModel.ROOM,
@@ -156,7 +156,7 @@ export const getAllBoardIds = async (
 // function to get new board name
 export const getBoardName = async (
     persis: IPersistenceRead,
-    roomId: string
+    roomId: string | undefined,
 ): Promise<string> => {
     const boardArray = await getBoardRecordByRoomId(persis, roomId);
 


### PR DESCRIPTION
# Brief Title
Settings modal contains initial values for `boardName` and `boardStatus`

## Acceptance Criteria fulfillment

- [X] The Settings Modal should contain pre-filled values of Board Name and Board Privacy when the modal is opened to edit settings.

Fixes #75 

## Video/Screenshots
[init-values.webm](https://github.com/RocketChat/Apps.Whiteboard/assets/95426993/97587f6b-371e-4bf1-bc42-8969292d9671)
