### PR TITLE
Fix: Ensure whiteboard name updates reflect in UI after settings change

### DIFF
--- a/whiteboard/handlers/ExecuteViewSubmitHandler.ts
+++ b/whiteboard/handlers/ExecuteViewSubmitHandler.ts
@@ -132,10 +132,8 @@ export class ExecuteViewSubmitHandler {
                                     .getUpdater()
                                     .message(messageId, AppSender);
 
-                                const url =
-                                    message.getBlocks()[1]["elements"][1][
-                                        "url"
-                                    ];
+                                const Value = message.getBlocks()[1]["elements"][0].value;
+                                const url = Value.split(',')[0].trim()
                                 // Updating header block for new boardname
                                 const updateHeaderBlock =
                                     await buildHeaderBlock(


### PR DESCRIPTION
# Brief Title

Whiteboard Name Not Updating in UI

## Acceptance Criteria fulfillment

- [x]  The whiteboard name should update immediately in the UI upon saving changes in settings.
- [x] Ensure no backend errors occur during the name update process.

Fixes #95 

## Video/Screenshots


https://github.com/user-attachments/assets/144a2b68-9c70-4a06-a55b-198e9b5c66fa

